### PR TITLE
Add totalCost and utxos to simulation

### DIFF
--- a/stats/index.js
+++ b/stats/index.js
@@ -31,6 +31,7 @@ for (var j = 0; j < 100; ++j) {
       stage.txos.forEach((txo) => simulation.run([txo]))
     })
 
+    simulation.finish()
     results.push(simulation)
   }
 }
@@ -48,12 +49,14 @@ function merge (results) {
       result.failed += stats.failed
       result.fees += stats.fees
       result.bytes += stats.bytes
+      result.utxos += stats.utxos
       result.average = {
         nInputs: result.inputs / result.transactions,
         nOutputs: result.outputs / result.transactions,
         fee: Math.round(result.fees / result.transactions),
         feeRate: Math.round(result.fees / result.bytes)
       }
+      result.totalCost += stats.totalCost
     } else {
       resultMap[stats.name] = Object.assign({}, stats)
     }
@@ -69,7 +72,7 @@ function pad (i) {
 
 merge(results).sort((a, b) => {
   if (a.stats.transactions !== b.stats.transactions) return b.stats.transactions - a.stats.transactions
-  return a.stats.fees - b.stats.fees
+  return a.stats.totalCost - b.stats.totalCost
 
 // top 20 only
 }).slice(0, 20).forEach((x, i) => {
@@ -84,6 +87,8 @@ merge(results).sort((a, b) => {
     '| feeRate', pad('' + stats.average.feeRate),
     '| nInputs', pad(stats.average.nInputs),
     '| nOutputs', pad(stats.average.nOutputs),
-    '| DNF', (100 * DNF).toFixed(2) + '%'
+    '| DNF', (100 * DNF).toFixed(2) + '%',
+    '| totalCost', pad('' + Math.round(stats.totalCost / 1000)),
+    '| utxos', pad('' + stats.utxos)
   )
 })

--- a/stats/simulation.js
+++ b/stats/simulation.js
@@ -104,4 +104,11 @@ Simulation.prototype.run = function (outputs) {
   return true
 }
 
+Simulation.prototype.finish = function () {
+  let utxos = this.getUTXOs()
+  this.stats.utxos = utxos.length
+  let costToEmpty = utils.transactionBytes(utxos, []) * this.feeRate // output cost is negligible
+  this.stats.totalCost = this.stats.fees + costToEmpty
+}
+
 module.exports = Simulation


### PR DESCRIPTION
Inspired by xekyo work on https://github.com/Xekyo/CoinSelectionSimulator and the thesis, I have added `totalCost` and `utxo` to the statistics, since some strategies create rather big utxo sets that are hard to spend later.

It's not actually that visible on this simulation, and what produces low fees produces low totalCost; but it is noticable on the bigger simulation murch uses (which I plan to add here too, if only for comparison). Some strategies produce giant utxo set on his dataset.

Coinselect algorithm should IMO perform well on smaller wallets, which this repo simulates, but should perform passable on big accounts too, which the bigger simulation does; and you need to account for the "cost to empty" there.