### PR TITLE
Wait for balance

### DIFF
--- a/stats/index.js
+++ b/stats/index.js
@@ -28,7 +28,7 @@ for (var j = 0; j < 100; ++j) {
       stage.utxos.forEach(x => simulation.addUTXO(x))
 
       // now, run stage.txos.length transactions
-      stage.txos.forEach((txo) => simulation.run([txo]))
+      stage.txos.forEach((txo) => simulation.runQueued([txo]))
     })
 
     simulation.finish()


### PR DESCRIPTION
As discussed elsewhere - this adds a queue, and waits until there are good utxos

There is both good and bad point in this - it more closely simulates user's behavior, and it makes some simulations more comparable... however, with the strategies with high DNF (blackjack, bnb without fallback), it might return "too good" numbers.

Both approaches have pros and cons