### PR TITLE
Using input+output sizes from stats in simulation

### DIFF
--- a/stats/index.js
+++ b/stats/index.js
@@ -5,6 +5,42 @@ let max = 142251558 // 1000 USD
 let feeRate = 56 * 100
 let results = []
 
+let walletType = 'p2pkh' // set to either p2pkh or p2sh
+
+// data from blockchaing from ~august 2015 - august 2017
+// see https://gist.github.com/runn1ng/8e2881e5bb44e01748e46b3d1c549038
+// these are 2-of-3 lengths, most common p2sh (66%), percs changed so they add to 100
+let scripthashScriptLengthData = {
+  prob: 0.16,
+  inLengthPercs: {
+    252: 25.29,
+    253: 49.77,
+    254: 24.94
+  },
+  outLength: 23
+}
+
+// these are compressed key length (90% of p2pkh inputs)
+// percs changed so they add to 100
+let pubkeyhashScriptLengthData = {
+  prob: 0.84,
+  inLengthPercs: {
+    105: 0.4,
+    106: 50.7,
+    107: 48.81,
+    108: 0.09
+  },
+  outLength: 25
+}
+
+let selectedData = walletType === 'p2pkh' ? pubkeyhashScriptLengthData : scripthashScriptLengthData
+let inLengthProbs = selectedData.inLengthPercs
+
+let outLengthProbs = {};
+[scripthashScriptLengthData, pubkeyhashScriptLengthData].forEach(({prob, outLength}) => {
+  outLengthProbs[outLength] = prob
+})
+
 // n samples
 for (var j = 0; j < 100; ++j) {
   if (j % 200 === 0) console.log('Iteration', j)
@@ -12,9 +48,8 @@ for (var j = 0; j < 100; ++j) {
   let stages = []
 
   for (var i = 1; i < 4; ++i) {
-    let utxos = Simulation.generateTxos(20 / i, min, max)
-    let txos = Simulation.generateTxos(80 / i, min, max / 3)
-
+    let utxos = Simulation.generateTxos(20 / i, min, max, inLengthProbs)
+    let txos = Simulation.generateTxos(80 / i, min, max / 3, outLengthProbs)
     stages.push({ utxos, txos })
   }
 

--- a/stats/package.json
+++ b/stats/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "fisher-yates": "^1.0.3"
+    "fisher-yates": "^1.0.3",
+    "weighted": "^0.3.0"
   }
 }

--- a/stats/simulation.js
+++ b/stats/simulation.js
@@ -1,3 +1,5 @@
+var weighted = require('weighted')
+
 function rayleight (a, b) {
   return a + b * Math.sqrt(-Math.log(uniform(0, 1)))
 }
@@ -32,13 +34,12 @@ function Simulation (name, algorithm, feeRate) {
   this.k = 0
 }
 
-Simulation.generateTxos = function (n, min, max) {
+Simulation.generateTxos = function (n, min, max, scriptSizes) {
   let txos = []
   for (let i = 0; i < n; ++i) {
     let v = rayleight(min, max) >>> 0
 
-    let s = 106
-    if (Math.random() > 0.9) s = 300
+    let s = parseInt(weighted.select(scriptSizes))
 
     txos.push({
       address: randomAddress(),


### PR DESCRIPTION
Some strategies (right now only blackjack I think, in the future bnb) are taking output script size into account.

Currently, it takes wrong output sizes into account; this is fixing it.