### PR TITLE
Fix the way casting to int

### DIFF
--- a/split.js
+++ b/split.js
@@ -22,7 +22,7 @@ module.exports = function split (utxos, outputs, feeRate) {
   var splitOutputsCount = outputs.reduce(function (a, x) {
     return a + !x.value
   }, 0)
-  var splitValue = (remaining / splitOutputsCount) >>> 0
+  var splitValue = Math.floor(remaining / splitOutputsCount)
 
   // ensure every output is either user defined, or over the threshold
   if (!outputs.every(function (x) {


### PR DESCRIPTION
In JavaScript, bit-operator treats operand as double so it shouldn't be used for casting.