### PR TITLE
RFC: add consolidate stragegy

### DIFF
--- a/consolidate.js
+++ b/consolidate.js
@@ -1,0 +1,36 @@
+var utils = require('./utils')
+
+// similar to accumulative but add all inputs
+module.exports = function consolidate (utxos, outputs, feeRate) {
+  if (!isFinite(utils.uintOrNaN(feeRate))) return {}
+  var bytesAccum = utils.transactionBytes([], outputs)
+
+  var inAccum = 0
+  var inputs = []
+  var outAccum = utils.sumOrNaN(outputs)
+
+  for (var i = 0; i < utxos.length; ++i) {
+    var utxo = utxos[i]
+    var utxoBytes = utils.inputBytes(utxo)
+    var utxoFee = feeRate * utxoBytes
+    var utxoValue = utils.uintOrNaN(utxo.value)
+
+    // skip detrimental input
+    if (utxoFee > utxo.value) {
+      if (i === utxos.length - 1) return { fee: feeRate * (bytesAccum + utxoBytes) }
+      continue
+    }
+
+    bytesAccum += utxoBytes
+    inAccum += utxoValue
+    inputs.push(utxo)
+
+    var fee = feeRate * bytesAccum
+  }
+
+  // if we can satisfy requirements we finalize it
+  if (inAccum >= outAccum + fee) return utils.finalize(inputs, outputs, feeRate)
+
+  // otherwise, fail. return only fee
+  return { fee: feeRate * bytesAccum }
+}

--- a/test/consolidate.js
+++ b/test/consolidate.js
@@ -1,0 +1,19 @@
+var consolidate = require('../consolidate')
+var fixtures = require('./fixtures/consolidate.json')
+var tape = require('tape')
+var utils = require('./_utils')
+
+fixtures.forEach(function (f) {
+  tape(f.description, function (t) {
+    var inputs = utils.expand(f.inputs, true)
+    var actual = consolidate(inputs, f.outputs, f.feeRate)
+
+    t.same(actual, f.expected)
+    if (actual.inputs) {
+      var feedback = consolidate(actual.inputs, actual.outputs, f.feeRate)
+      t.same(feedback, f.expected)
+    }
+
+    t.end()
+  })
+})

--- a/test/fixtures/consolidate.json
+++ b/test/fixtures/consolidate.json
@@ -1,0 +1,108 @@
+[
+  {
+    "description": "3 ins, 2 outs",
+    "feeRate": 5,
+    "inputs": [
+      {
+        "value": 3000
+      },
+      {
+        "value": 3000
+      },
+      {
+        "value": 3000
+      }
+    ],
+    "outputs": [
+      {
+        "value": 4000,
+        "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm"
+      }
+    ],
+    "expected": {
+      "fee": 2610,
+      "inputs": [
+        {
+          "i": 0,
+          "value": 3000
+        },
+        {
+          "i": 1,
+          "value": 3000
+        },
+        {
+          "i": 2,
+          "value": 3000
+        }
+      ],
+      "outputs": [
+        {
+          "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm",
+          "value": 4000
+        },
+        {
+          "value": 2390
+        }
+      ]
+    }
+  },
+  {
+    "description": "1 output, no change",
+    "feeRate": 10,
+    "inputs": [
+      102001
+    ],
+    "outputs": [
+      {
+        "value": 100000,
+        "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm"
+      }
+    ],
+    "expected": {
+      "inputs": [
+        {
+          "i": 0,
+          "value": 102001
+        }
+      ],
+      "outputs": [
+        {
+          "value": 100000,
+          "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm"
+        }
+      ],
+      "fee": 2001
+    }
+  },
+  {
+    "description": "1 output, change expected",
+    "feeRate": 5,
+    "inputs": [
+      106001
+    ],
+    "outputs": [
+      {
+        "value": 100000,
+        "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm"
+      }
+    ],
+    "expected": {
+      "inputs": [
+        {
+          "i": 0,
+          "value": 106001
+        }
+      ],
+      "outputs": [
+        {
+          "value": 100000,
+          "address": "1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm"
+        },
+        {
+          "value": 4871
+        }
+      ],
+      "fee": 1130
+    }
+  }
+]


### PR DESCRIPTION
After discussion here https://github.com/bitcoinjs/coinselect/issues/43 I believe this is a better way to implement consolidation strategy. While I happily use `split` for `sendMax` functionality, I think slightly adjusted `accumulative` strategy will allow tech-savvy users to make regular BTC transactions (utilizing batch send when needed) while sweeping _all_ their inputs for consolidation.

In this PR I basically copied `accumulative` strategy while fixing the loop to add all inputs and not stop when fee+amount requirements are satisfied. Added couple of tests, but probably not enough.
Did not change any documentation. Looking for an ACK before proceeding.
